### PR TITLE
Add missing CATCH_MICROSERVICE_SDK_DRY_RUN option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pack": "cp package.json package-lock.json dst/ && cd dst && npm ci --production && npm ls && find . -name \"*.d.ts\" | xargs rm && find . -name \"*.js.map\" | xargs rm && rm -Rf ./node_modules/@types && zip -rqy ../dst.zip . && cd ..",
     "postpack": "node -e \"require('fs').statSync('./dst.zip').size > 1024 * 1024 * 50 && [console.log('artifact has to be smaller than 50MB'), process.exit(1)]\"",
     "pretest": "npm run build:tsc -- -p ./tsconfig-test.json",
-    "test": "mocha --exit -t 20000 dst/**/__test__/**/*.js",
+    "test": "CATCH_MICROSERVICE_SDK_DRY_RUN=true mocha --exit -t 20000 dst/**/__test__/**/*.js",
     "test:ci": "npm run test -- --forbid-only",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "run-local:api": "npm run build && vingle-corgi run-local \"./dst/api/index.js\"",


### PR DESCRIPTION
## AS-IS
- 새로운 저장소를 생성할때 해당 template에서 CATCH_MICROSERVICE_SDK_DRY_RUN옵션이 커져있지 않아 테스트시 실수로 stub, mock을 하지 않을 경우 API를 호출함

## TO-BE
- 테스트 시에는 정의되지 않은 API를 호출할경우 테스트가 실패하도록 되어야함

## Changes
- 기본적으로 CATCH_MICROSERVICE_SDK_DRY_RUN를 true로 설정하도록 변경
